### PR TITLE
Changed to open class

### DIFF
--- a/ACTextField.swift
+++ b/ACTextField.swift
@@ -15,10 +15,10 @@ public protocol ACTextFieldDelegate {
 //        return true
 //    }
 //}
-public class ACTextField: UITextField,UITextFieldDelegate {
+open class ACTextField: UITextField,UITextFieldDelegate {
 
     public var ACDelegate  : ACTextFieldDelegate?
-    public var strictMode = false
+    open var strictMode = false
     private var ACDelegateResult = true
     private var autoCompleteDataSet = [String]()
     private var autoCompleteCharacterCount = 0
@@ -44,7 +44,7 @@ public class ACTextField: UITextField,UITextFieldDelegate {
     }
     
     
-    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool { //1
+    open func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool { //1
         if let del = ACDelegate?.ACTextField(self, shouldChangeCharactersIn: range, replacementString: string){
             ACDelegateResult = del
         }

--- a/ACTextField/Classes/ACTextField.swift
+++ b/ACTextField/Classes/ACTextField.swift
@@ -28,7 +28,8 @@ open class ACTextField: UITextField,UITextFieldDelegate {
     public func setAutoCompleteWith(DataSet dataSet:[String]){
         autoCompleteDataSet = dataSet
     }
-    override init(frame: CGRect) {
+    
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         self.delegate = self
     }

--- a/ACTextField/Classes/ACTextField.swift
+++ b/ACTextField/Classes/ACTextField.swift
@@ -11,10 +11,10 @@ public protocol ACTextFieldDelegate {
     func  ACTextField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool
 }
 
-public class ACTextField: UITextField,UITextFieldDelegate {
+open class ACTextField: UITextField,UITextFieldDelegate {
     
-    public var ACDelegate  : ACTextFieldDelegate?
-    public var strictMode = false
+    open var ACDelegate  : ACTextFieldDelegate?
+    open var strictMode = false
     private var ACDelegateResult = true
     private var autoCompleteDataSet = [String]()
     private var autoCompleteCharacterCount = 0

--- a/ACTextField/Classes/ACTextField.swift
+++ b/ACTextField/Classes/ACTextField.swift
@@ -40,7 +40,7 @@ open class ACTextField: UITextField,UITextFieldDelegate {
     }
     
     
-    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool { //1
+    open func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool { //1
         if let del = ACDelegate?.ACTextField(self, shouldChangeCharactersIn: range, replacementString: string){
             ACDelegateResult = del
         }


### PR DESCRIPTION
Changing this to open class will allow people to subclass the ACTextField.  

I for example wanted to add padding to the super class UITextField and in order to do that I was going to subclass your ACTextField.  Because of its current protection level `public` it is not subclass-able outside of its defining module. 

Here's an example valid use case for subclassing your class. 

```swift
class TextField: ACTextField {

    let padding = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: 5)

    override open func textRect(forBounds bounds: CGRect) -> CGRect {
        return UIEdgeInsetsInsetRect(bounds, padding)
    }

    override open func placeholderRect(forBounds bounds: CGRect) -> CGRect {
        return UIEdgeInsetsInsetRect(bounds, padding)
    }

    override open func editingRect(forBounds bounds: CGRect) -> CGRect {
        return UIEdgeInsetsInsetRect(bounds, padding)
    }
}
```